### PR TITLE
Polyfills for IE compatibility

### DIFF
--- a/src/QuickApp/ClientApp/src/polyfills.ts
+++ b/src/QuickApp/ClientApp/src/polyfills.ts
@@ -2,7 +2,7 @@
 // More Templates: https://www.ebenmonney.com/templates
 // Email: support@ebenmonney.com
 // ====================================================
-
+ 
 /**
  * This file includes polyfills needed by Angular and is loaded before the app.
  * You can add your own extra polyfills to this file.
@@ -24,20 +24,20 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/weak-map';
-// import 'core-js/es6/set';
+ import 'core-js/es6/symbol';
+ import 'core-js/es6/object';
+ import 'core-js/es6/function';
+ import 'core-js/es6/parse-int';
+ import 'core-js/es6/parse-float';
+ import 'core-js/es6/number';
+ import 'core-js/es6/math';
+ import 'core-js/es6/string';
+ import 'core-js/es6/date';
+ import 'core-js/es6/array';
+ import 'core-js/es6/regexp';
+ import 'core-js/es6/map';
+ import 'core-js/es6/weak-map';
+ import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
@@ -48,7 +48,7 @@
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
-import 'core-js/es7/reflect';
+ import 'core-js/es7/reflect';
 
 
 /**


### PR DESCRIPTION
Uncommenting lined that adds polyfils for Internet Explorer compatibility. Many users still run internet explorer and it is therefore valuable to have the QuickApp application work with internet explorer for some time still.