### PR TITLE
Correctly set the token URL in the Oidc service

### DIFF
--- a/QuickApp/ClientApp/src/app/services/oidc-helper.service.ts
+++ b/QuickApp/ClientApp/src/app/services/oidc-helper.service.ts
@@ -17,7 +17,6 @@ import { LoginResponse } from '../models/login-response.model';
 @Injectable()
 export class OidcHelperService {
 
-    private get baseUrl() { return this.configurations.baseUrl; }
     private clientId = 'quickapp_spa';
     private scope = 'openid email phone profile offline_access roles quickapp_api';
 
@@ -39,7 +38,7 @@ export class OidcHelperService {
             .append('grant_type', 'password')
             .append('scope', this.scope);
 
-        this.oauthService.issuer = this.baseUrl;
+        this.oauthService.issuer = this.configurations.tokenUrl;
 
         return from(this.oauthService.loadDiscoveryDocument())
             .pipe(mergeMap(() => {
@@ -54,7 +53,7 @@ export class OidcHelperService {
             .append('client_id', this.clientId)
             .append('grant_type', 'refresh_token');
 
-        this.oauthService.issuer = this.baseUrl;
+        this.oauthService.issuer = this.configurations.tokenUrl;
 
         return from(this.oauthService.loadDiscoveryDocument())
             .pipe(mergeMap(() => {


### PR DESCRIPTION
I noticed that even though I set the token URL in the environment file, it didn't take effect. I traced the problem and found that it is caused by a small oversight in the `oidc-helper.service.ts` file. Currently, the token URL was always set to the base URL. This change fixes that. The Oidc service now uses the token URL from the environment file.

This problem is likely caused by the fact that this project template wasn't sufficiently tested with different base and token URLs.